### PR TITLE
Bugfix in admin forms using PermissionInline as inlines.

### DIFF
--- a/authority/admin.py
+++ b/authority/admin.py
@@ -30,7 +30,6 @@ class PermissionInline(generic.GenericTabularInline):
             perm_choices = get_choices_for(self.parent_model)
             kwargs['label'] = _('permission')
             kwargs['widget'] = forms.Select(choices=perm_choices)
-            return db_field.formfield(**kwargs)
         return super(PermissionInline, self).formfield_for_dbfield(db_field, **kwargs)
 
 class ActionPermissionInline(PermissionInline):


### PR DESCRIPTION
Hello,

This is basically the same fix as suggested by the following pull-request on bitbucket:

https://bitbucket.org/jezdez/django-authority/pull-request/1/bugfix-in-admin-forms-using

by Ratnadeep Debnath

It really is an issue because the modeladmins which want to use the inline are rendered useless this way.

I hope this fix can be incorporated and released to pypi soon.

Thank you very much in advance,

Best regards,

Rico
