### PR TITLE
Python3 + Django 1.5 compatibility

### DIFF
--- a/authority/admin.py
+++ b/authority/admin.py
@@ -2,7 +2,6 @@ from django import forms, template
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext, ungettext, ugettext_lazy as _
 from django.shortcuts import render_to_response
-from django.utils.encoding import force_text
 from django.utils.safestring import mark_safe
 from django.forms.formsets import all_valid
 from django.contrib import admin
@@ -10,6 +9,11 @@ from django.contrib.admin import helpers
 from django.contrib.contenttypes import generic
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
+
+try:
+    from django.utils.encoding import force_text
+except ImportError:
+    from django.utils.encoding import force_unicode as force_text
 
 try:
     from django.contrib.admin import actions


### PR DESCRIPTION
Django changed name for force_unicode. Added backward compatibility too.
