### PR TITLE
changed deprecated "django.conf.urls.defaults" to proper "django.conf.urls"  

### DIFF
--- a/authority/urls.py
+++ b/authority/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('authority.views',
     url(r'^permission/add/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$',

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,5 +1,5 @@
 
-from django.conf.urls.defaults import patterns, include, handler500, url
+from django.conf.urls import patterns, include, handler500, url
 from django.conf import settings
 from django.contrib import admin
 import authority


### PR DESCRIPTION
Based on my testing of Django 1.6b2, looks like "django.conf.urls.defaults" will be fully deprecated and reverse-incompatible in Django 1.6, so the imports in django-authority will need to be addressed before the package is 1.6 compatible.
