### PR TITLE
fixing invalid syntax error

### DIFF
--- a/example/users/admin.py
+++ b/example/users/admin.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.admin import UserAdmin
-from example.users.User
+from example.users.models import User
 
 
 admin.site.register(User, UserAdmin)


### PR DESCRIPTION
Got the following error when installing django-authority:
  File "/path/to/env/build/django-authority/example/users/admin.py", line 2
    from example.users.User
                          ^
SyntaxError: invalid syntax
