### PR TITLE
Fix CSRF failure posting permission change form

### DIFF
--- a/authority/templates/admin/permission_change_form.html
+++ b/authority/templates/admin/permission_change_form.html
@@ -23,6 +23,7 @@
 
 {% block content %}<div id="content-main">
 <form action="{{ form_url }}" method="post" id="{{ opts.module_name }}_form">
+{% csrf_token %}
 <div>
 {% if is_popup %}<input type="hidden" name="_popup" value="1" />{% endif %}
 {% if save_on_top %}{% submit_row %}{% endif %}


### PR DESCRIPTION
Add missing `{% csrf_token %}` in form.

fixes #18
