### PR TITLE
Fix hardcoded jsi18n script path

### DIFF
--- a/authority/templates/admin/permission_change_form.html
+++ b/authority/templates/admin/permission_change_form.html
@@ -2,7 +2,7 @@
 {% load i18n admin_modify admin_static %}
 
 {% block extrahead %}{{ block.super }}
-<script type="text/javascript" src="../../../jsi18n/"></script>
+<script type="text/javascript" src="{% url 'admin:jsi18n' %}"></script>
 {{ media }}
 {% endblock %}
 


### PR DESCRIPTION
Use normal Django URL reversal instead of hardcoded relative path.
