### PR TITLE
Django 1.7 compatibility

### DIFF
--- a/authority/admin.py
+++ b/authority/admin.py
@@ -1,3 +1,4 @@
+import django
 from django import forms, template
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext, ungettext, ugettext_lazy as _
@@ -20,6 +21,11 @@ try:
 except ImportError:
     actions = False
 
+# From 1.7 forward, Django consistenly uses the name "utils", 
+# not "util". We alias for backwards compatibility.
+if django.VERSION[:2] < (1, 7):
+    forms.utils = forms.util
+
 from authority.models import Permission
 from authority.widgets import GenericForeignKeyRawIdWidget
 from authority import get_choices_for
@@ -40,7 +46,7 @@ class ActionPermissionInline(PermissionInline):
     raw_id_fields = ()
     template = 'admin/edit_inline/action_tabular.html'
 
-class ActionErrorList(forms.util.ErrorList):
+class ActionErrorList(forms.utils.ErrorList):
     def __init__(self, inline_formsets):
         for inline_formset in inline_formsets:
             self.extend(inline_formset.non_form_errors())

--- a/authority/utils.py
+++ b/authority/utils.py
@@ -1,8 +1,17 @@
+import django
+from django.conf import settings
 from django.contrib import auth
 
 
 def get_user_class():
-    if hasattr(auth, "get_user_model"):
+    """
+    Returns the User model class. In Django 1.7 and above, get_user_model()
+    internally uses the App Registry, which may not be queried until it is ready.
+    We can break this cycle via indirection by returning a string instead.
+    """
+    if django.VERSION[:2] >= (1, 7):
+        return settings.AUTH_USER_MODEL
+    elif hasattr(auth, "get_user_model"):
         return auth.get_user_model()
     else:
         return auth.models.User


### PR DESCRIPTION
Here are some quick and easy fixes that get django-authority running on Django 1.7.

There may be more silent bugs that haven't manifested yet, but this is a good start and doesn't break compatibility with older versions.

Cheers! :wine_glass: