### PR TITLE
Fixed typo

### DIFF
--- a/authority/templatetags/permissions.py
+++ b/authority/templatetags/permissions.py
@@ -124,7 +124,7 @@ def ifhasperm(parser, token):
             meh
         {% endifhasperm %}
 
-        {% if hasperm "poll_permission.change_poll" request.user %}
+        {% ifhasperm "poll_permission.change_poll" request.user %}
             lalala
         {% else %}
             meh

--- a/docs/check_templates.txt
+++ b/docs/check_templates.txt
@@ -28,7 +28,7 @@ Syntax::
 
 Example::
 
-    {% if hasperm "poll_permission.change_poll" request.user %}
+    {% ifhasperm "poll_permission.change_poll" request.user %}
         lalala
     {% else %}
         meh


### PR DESCRIPTION
`if hasperm` -> `ifhasperm`
