### PR TITLE
Django1.8: Use prefetch_related for M2M to `user__groups`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: python
 python:
   - "2.7"
 env:
-  - TOX_ENV=py26-django13
   - TOX_ENV=py26-django14
   - TOX_ENV=py26-django15
   - TOX_ENV=py26-django16
-  - TOX_ENV=py27-django13
   - TOX_ENV=py27-django14
   - TOX_ENV=py27-django15
   - TOX_ENV=py27-django16

--- a/authority/managers.py
+++ b/authority/managers.py
@@ -25,8 +25,14 @@ class PermissionManager(models.Manager):
         # http://bugs.python.org/issue2460
         # Which is triggered by django's deepcopy which backports that fix in
         # Django 1.2
-        return perms.select_related('user', 'user__groups', 'creator').filter(
-            Q(user__pk=user.pk) | Q(group__in=user.groups.all()))
+        return perms.select_related(
+            'user',
+            'creator'
+        ).prefetch_related(
+            'user__groups'
+        ).filter(
+            Q(user__pk=user.pk) | Q(group__in=user.groups.all())
+        )
 
     def user_permissions(
             self, user, perm, obj, approved=True, check_groups=True):

--- a/example/users/models.py
+++ b/example/users/models.py
@@ -6,7 +6,7 @@ from django.utils import timezone
 class User(AbstractBaseUser, PermissionsMixin):
     USERNAME_FIELD = 'email'
     REQUIRED_FIELDS = ['first_name', 'last_name']
-    
+
     first_name = models.CharField(max_length=50)
     last_name = models.CharField(max_length=50)
     email = models.EmailField(unique=True)

--- a/tox.ini
+++ b/tox.ini
@@ -1,14 +1,14 @@
 [tox]
 envlist =
-    py26-django{13,14,15,16},
-    py27-django{13,14,15,16,17},
-    py33-django{15,16,17}
+    py26-django{14,15,16},
+    py27-django{14,15,16,17,18},
+    py33-django{15,16,17,18}
 
 [testenv]
 commands = python example/manage.py test authority
 deps =
-    django13: Django>=1.3, <1.4
     django14: Django>=1.4, <1.5
     django15: Django>=1.5, <1.6
     django16: Django>=1.6, <1.7
     django17: Django>=1.7, <1.8
+    django18: Django>=1.8, <1.9


### PR DESCRIPTION
Add `tox` tests for Django 1.8.

Since `select_related` doesn't work with M2M fields, Django 1.8 is raising an error.

Switched to using `prefetch_related` and dropped support for Django 1.3.