### PR TITLE
Fixes for generic foreign key raw id widget

### DIFF
--- a/authority/admin.py
+++ b/authority/admin.py
@@ -158,7 +158,8 @@ class PermissionAdmin(admin.ModelAdmin):
             for gfk in self.model._meta.virtual_fields:
                 if gfk.fk_field == db_field.name:
                     kwargs["widget"] = GenericForeignKeyRawIdWidget(
-                        gfk.ct_field, self.admin_site._registry.keys()
+                        gfk.ct_field, self.admin_site._registry.keys(),
+                        request=kwargs.get("request", None)
                     )
                     break
         return super(PermissionAdmin, self).formfield_for_dbfield(db_field, **kwargs)

--- a/authority/admin.py
+++ b/authority/admin.py
@@ -149,13 +149,17 @@ class PermissionAdmin(admin.ModelAdmin):
 
     def formfield_for_dbfield(self, db_field, **kwargs):
         # For generic foreign keys marked as generic_fields we use a special widget
+        try:
+            model_meta_fields = self.model._meta.virtual_fields
+        except AttributeError:
+            model_meta_fields = self.model._meta.private_fields
         names = [
             f.fk_field
-            for f in self.model._meta.virtual_fields
+            for f in model_meta_fields
             if f.name in self.generic_fields
         ]
         if db_field.name in names:
-            for gfk in self.model._meta.virtual_fields:
+            for gfk in model_meta_fields:
                 if gfk.fk_field == db_field.name:
                     kwargs["widget"] = GenericForeignKeyRawIdWidget(
                         gfk.ct_field, self.admin_site._registry.keys(),

--- a/authority/widgets.py
+++ b/authority/widgets.py
@@ -20,15 +20,16 @@ function showGenericRelatedObjectLookupPopup(ct_select, triggering_link, url_bas
 
 
 class GenericForeignKeyRawIdWidget(ForeignKeyRawIdWidget):
-    def __init__(self, ct_field, cts=[], attrs=None):
+    def __init__(self, ct_field, cts=[], attrs=None, request=None):
         self.ct_field = ct_field
         self.cts = cts
+        self.request = request
         forms.TextInput.__init__(self, attrs)
 
     def render(self, name, value, attrs=None):
         if attrs is None:
             attrs = {}
-        related_url = "../../../"
+        related_url = self.get_related_url()
         params = self.url_parameters()
         if params:
             url = "?" + "&amp;".join(["%s=%s" % (k, v) for k, v in params.iteritems()])
@@ -85,3 +86,11 @@ class GenericForeignKeyRawIdWidget(ForeignKeyRawIdWidget):
 
     def url_parameters(self):
         return {}
+
+    def get_related_url(self):
+        if self.request is None:
+            return "../../../"
+        path_info = self.request.path_info
+        app_name = self.request.resolver_match.app_name
+        path_components = list(filter(None, path_info.split("/")))
+        return "../" * list(reversed(path_components)).index(app_name)

--- a/authority/widgets.py
+++ b/authority/widgets.py
@@ -80,5 +80,8 @@ class GenericForeignKeyRawIdWidget(ForeignKeyRawIdWidget):
         )
         return mark_safe(u"".join(output) + content_types)
 
+    def get_context(self, name, value, attrs):
+        return forms.TextInput.get_context(self, name, value, attrs)
+
     def url_parameters(self):
         return {}

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ commands =
     coverage report
 deps =
     coverage
+    mock
     dj111: Django>=1.11,<2.0
     dj22: Django>=2.2,<2.3
 


### PR DESCRIPTION
I am porting a Django app to Django 1.11 and found some issues in the latest version of `django-authority` while doing so.

The class `GenericForeignKeyRawIdWidget` has `ForeignKeyRawIdWidget` as a base class but its `__init__` method calls `forms.TextInput.__init__`(I am guessing that this is why its class name starts with the word "Generic"). The following PR is my attempt to address errors when attempting to view an individual permission from the permissions list view.

The first commit on this branch addresses an issue that occurs when `render` is called on this widget. During `render` a call is made to `forms.TextInput.render` which then calls `self.get_context`.  Unfortunately this goes to `ForeignKeyRawIdWidget.get_context` which then blows up as it the instance of the class is missing members that would have been added by `ForeignKeyRawIdWidget.__init__`. In order to avoid this I have added a `get_context` which simply delegates to `forms.TextInput.get_context` (resolves up; but it is calling into something that has been initialised).

The second commit addresses an issue that occurs when clicking the anchor of class `related-lookup` from the rendered widget. In the app that I am porting from Django 1.6.11, using django-authority 0.10 to Django 1.11 using the latest version of django-authority there are differences in the form of the URL where the widget is rendered. With the old version of Django and Django-Authority the path of the URL is like this `admin/authority/permission/21852/` where as with Django 1.11 and latest Django-Authority I am seeing `admin/authority/permission/21852/change/`. Thus having `related_url` hard coded to `"../../../"` is not going to work for both paths. What I have done is past the `request` object into the widget so that it can work out how many `../` it should use to get back to the root of the "related" path.

If you think this PR is off course or wrong could you please let me know :) thank you.