### PR TITLE
django-authority for Python 2.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         "Framework :: Django",
     ],
     install_requires=["django"],
-    setup_requires=["setuptools_scm"],
+    setup_requires=["setuptools_scm==5.0.2"],
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
Use `setuptools_scm==5.0.2", because from 6.0.0 only supports Python >= 3.6