### PR TITLE
Updates to support Django 4.x

### DIFF
--- a/authority/admin.py
+++ b/authority/admin.py
@@ -1,6 +1,6 @@
 from django import forms
 from django.http import HttpResponseRedirect
-from django.utils.translation import ugettext, ungettext, ugettext_lazy as _
+from django.utils.translation import gettext, ngettext, gettext_lazy as _
 from django.shortcuts import render
 from django.utils.safestring import mark_safe
 from django.forms.formsets import all_valid
@@ -100,7 +100,7 @@ def edit_permissions(modeladmin, request, queryset):
 
     context = {
         "errors": ActionErrorList(formsets),
-        "title": ugettext("Permissions for %s") % force_text(opts.verbose_name_plural),
+        "title": gettext("Permissions for %s") % force_text(opts.verbose_name_plural),
         "inline_admin_formsets": inline_admin_formsets,
         "app_label": app_label,
         "change": True,
@@ -173,7 +173,7 @@ class PermissionAdmin(admin.ModelAdmin):
     def approve_permissions(self, request, queryset):
         for permission in queryset:
             permission.approve(request.user)
-        message = ungettext(
+        message = ngettext(
             "%(count)d permission successfully approved.",
             "%(count)d permissions successfully approved.",
             len(queryset),

--- a/authority/admin.py
+++ b/authority/admin.py
@@ -9,11 +9,7 @@ from django.contrib.admin import actions, helpers
 from django.contrib.contenttypes.admin import GenericTabularInline
 from django.contrib.contenttypes.models import ContentType
 from django.core.exceptions import PermissionDenied
-
-try:
-    from django.utils.encoding import force_text
-except ImportError:
-    from django.utils.encoding import force_unicode as force_text
+from django.utils.encoding import force_str
 
 from authority.models import Permission
 from authority.widgets import GenericForeignKeyRawIdWidget
@@ -100,7 +96,7 @@ def edit_permissions(modeladmin, request, queryset):
 
     context = {
         "errors": ActionErrorList(formsets),
-        "title": gettext("Permissions for %s") % force_text(opts.verbose_name_plural),
+        "title": gettext("Permissions for %s") % force_str(opts.verbose_name_plural),
         "inline_admin_formsets": inline_admin_formsets,
         "app_label": app_label,
         "change": True,
@@ -115,7 +111,7 @@ def edit_permissions(modeladmin, request, queryset):
         "show_delete": False,
         "action_checkbox_name": helpers.ACTION_CHECKBOX_NAME,
         "queryset": queryset,
-        "object_name": force_text(opts.verbose_name),
+        "object_name": force_str(opts.verbose_name),
     }
     template_name = getattr(
         modeladmin,

--- a/authority/decorators.py
+++ b/authority/decorators.py
@@ -1,6 +1,6 @@
 import inspect
+from urllib.parse import quote
 from django.http import HttpResponseRedirect
-from django.utils.http import urlquote
 from django.utils.functional import wraps
 from django.db.models import Model
 from django.apps import apps
@@ -65,7 +65,7 @@ def permission_required(perm, *lookup_variables, **kwargs):
                 if granted or request.user.has_perm(perm):
                     return view_func(request, *args, **kwargs)
             if redirect_to_login:
-                path = urlquote(request.get_full_path())
+                path = quote(request.get_full_path())
                 tup = login_url, redirect_field_name, path
                 return HttpResponseRedirect("%s?%s=%s" % tup)
             return permission_denied(request)

--- a/authority/forms.py
+++ b/authority/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.contrib.contenttypes.models import ContentType

--- a/authority/models.py
+++ b/authority/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.auth.models import Group
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from authority.managers import PermissionManager
 

--- a/authority/sites.py
+++ b/authority/sites.py
@@ -2,7 +2,7 @@ from inspect import getmembers, ismethod
 from django.apps import apps
 from django.db import models
 from django.db.models.base import ModelBase
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.core.exceptions import ImproperlyConfigured
 
 from authority.permissions import BasePermission

--- a/authority/urls.py
+++ b/authority/urls.py
@@ -1,37 +1,36 @@
-from django.conf.urls import url
+from django.urls import re_path
 from authority.views import (
     add_permission,
-    delete_permission,
     approve_permission_request,
     delete_permission,
 )
 
 
 urlpatterns = [
-    url(
+    re_path(
         r"^permission/add/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$",
         view=add_permission,
         name="authority-add-permission",
         kwargs={"approved": True},
     ),
-    url(
+    re_path(
         r"^permission/delete/(?P<permission_pk>\d+)/$",
         view=delete_permission,
         name="authority-delete-permission",
         kwargs={"approved": True},
     ),
-    url(
+    re_path(
         r"^request/add/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$",
         view=add_permission,
         name="authority-add-permission-request",
         kwargs={"approved": False},
     ),
-    url(
+    re_path(
         r"^request/approve/(?P<permission_pk>\d+)/$",
         view=approve_permission_request,
         name="authority-approve-permission-request",
     ),
-    url(
+    re_path(
         r"^request/delete/(?P<permission_pk>\d+)/$",
         view=delete_permission,
         name="authority-delete-permission-request",

--- a/authority/views.py
+++ b/authority/views.py
@@ -1,7 +1,7 @@
 from django.shortcuts import render, get_object_or_404
 from django.http import HttpResponseRedirect, HttpResponseForbidden
 from django.apps import apps
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 from django.template import loader
 from django.contrib.auth.decorators import login_required
 

--- a/authority/widgets.py
+++ b/authority/widgets.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.conf import settings
 from django.utils.safestring import mark_safe
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 from django.contrib.admin.widgets import ForeignKeyRawIdWidget
 
 

--- a/example/exampleapp/forms.py
+++ b/example/exampleapp/forms.py
@@ -1,5 +1,5 @@
 from django import forms
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from authority.forms import UserPermissionForm
 

--- a/example/exampleapp/permissions.py
+++ b/example/exampleapp/permissions.py
@@ -1,5 +1,5 @@
 from django.contrib.flatpages.models import FlatPage
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 import authority
 from authority.permissions import BasePermission

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,6 +1,7 @@
 import django.contrib.auth.views
-from django.conf.urls import include, handler500, url
+from django.conf.urls import include, handler500
 from django.conf import settings
+from django.urls import re_path
 
 import authority.views
 import authority.urls
@@ -13,21 +14,21 @@ authority.autodiscover()
 handler500  # flake8
 
 urlpatterns = (
-    url(
+    re_path(
         r"^authority/permission/add/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$",  # noqa
         view=authority.views.add_permission,
         name="authority-add-permission",
         kwargs={"approved": True, "form_class": SpecialUserPermissionForm},
     ),
-    url(
+    re_path(
         r"^request/add/(?P<app_label>[\w\-]+)/(?P<module_name>[\w\-]+)/(?P<pk>\d+)/$",  # noqa
         view=authority.views.add_permission,
         name="authority-add-permission-request",
         kwargs={"approved": False, "form_class": SpecialUserPermissionForm},
     ),
-    url(r"^authority/", include(authority.urls)),
-    url(r"^accounts/login/$", django.contrib.auth.views.LoginView.as_view()),
-    url(
+    re_path(r"^authority/", include(authority.urls)),
+    re_path(r"^accounts/login/$", django.contrib.auth.views.LoginView.as_view()),
+    re_path(
         r"^(?P<url>[\/0-9A-Za-z]+)$",
         example.exampleapp.views.top_secret,
         {"lala": "oh yeah!"},
@@ -36,7 +37,7 @@ urlpatterns = (
 
 if settings.DEBUG:
     urlpatterns += (
-        url(
+        re_path(
             r"^media/(?P<path>.*)$",
             django.views.static.serve,
             {"document_root": settings.MEDIA_ROOT,},


### PR DESCRIPTION
- Replace `ugettext` with `gettext`.
- Replace `force_text` with `force_str`.
- Replace `url` with `re_path`.
- Replace `urlquote` with `urllib.parse.quote`.

`ugettext`, `force_text` and `urlquote` were [deprecated in Django 3.0](https://docs.djangoproject.com/en/5.2/releases/3.0/#features-deprecated-in-3-0). `url` was [deprecated in Django 3.1](https://docs.djangoproject.com/en/5.2/releases/3.1/#features-deprecated-in-3-1).

The replacements are available since Django 2.0.