### PR TITLE
Replace deprecated pkg_resources with importlib.metadata

### DIFF
--- a/authority/__init__.py
+++ b/authority/__init__.py
@@ -1,8 +1,8 @@
-from pkg_resources import get_distribution, DistributionNotFound
+from importlib.metadata import PackageNotFoundError, version
 
 try:
-    __version__ = get_distribution("django-authority").version
-except DistributionNotFound:
+    __version__ = version("django-authority")
+except PackageNotFoundError:
     # package is not installed
     pass
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from pkg_resources import get_distribution
+from importlib.metadata import version
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
@@ -46,7 +46,7 @@ copyright = u"2009-2020, Jannis Leidel"
 # built documents.
 #
 # The full version, including alpha/beta/rc tags.
-release = get_distribution("django-authority").version
+release = version("django-authority")
 # The short X.Y version.
 version = ".".join(release.split(".")[:2])
 


### PR DESCRIPTION
`pkg_resources` was deprecated in Setuptools 67.5 and removed in Setuptools 82 (see pypa/setuptools#5007).

`importlib.metadata` is available in Python standard library since 3.8. But all versions older than 3.10 are EOL anyway.